### PR TITLE
Fixed premature COM/Interop release that caused build events to not fire

### DIFF
--- a/VSMonoTouch/VSMonoTouchPackage.cs
+++ b/VSMonoTouch/VSMonoTouchPackage.cs
@@ -28,25 +28,31 @@ namespace Follesoe.VSMonoTouch
     public sealed class VSMonoTouchPackage : Package
     {
         private DTE _dte;
+		private BuildEvents _BuildEvents;
 
         protected override void Initialize()
         {
             RegisterProjectFactory(new MonoTouchFlavorProjectFactory(this));
             
-            _dte = GetGlobalService(typeof(SDTE)) as DTE;         
+            _dte = GetGlobalService(typeof(SDTE)) as DTE;
 
-            if (_dte != null)
-            {
-                _dte.Events.BuildEvents.OnBuildBegin += MakeXibsNone;
-                _dte.Events.BuildEvents.OnBuildDone += MakeXibsPage;
-            }
+			if (_dte != null)
+			{
+				_BuildEvents = _dte.Events.BuildEvents;
+				_BuildEvents.OnBuildBegin += MakeXibsNone;
+				_BuildEvents.OnBuildDone += MakeXibsPage;
+			}
+			else
+			{
+				throw new Exception();
+			}
 
             base.Initialize();
         }
 
         private void MakeXibsNone(vsBuildScope scope, vsBuildAction action)
         {
-            var xibs = FindAllXibsInSolution();
+			var xibs = FindAllXibsInSolution();
             foreach(var xib in xibs)
             {
                 xib.Properties.Item("ItemType").Value = "None";
@@ -55,7 +61,7 @@ namespace Follesoe.VSMonoTouch
 
         private void MakeXibsPage(vsBuildScope Scope, vsBuildAction Action)
         {
-            var xibs = FindAllXibsInSolution();
+			var xibs = FindAllXibsInSolution();
             foreach (var xib in xibs)
             {
                 xib.Properties.Item("ItemType").Value = "Page";

--- a/VSMonoTouch/VSMonoTouchPackage.cs
+++ b/VSMonoTouch/VSMonoTouchPackage.cs
@@ -28,7 +28,7 @@ namespace Follesoe.VSMonoTouch
     public sealed class VSMonoTouchPackage : Package
     {
         private DTE _dte;
-		private BuildEvents _BuildEvents;
+        private BuildEvents _BuildEvents;
 
         protected override void Initialize()
         {
@@ -36,23 +36,23 @@ namespace Follesoe.VSMonoTouch
             
             _dte = GetGlobalService(typeof(SDTE)) as DTE;
 
-			if (_dte != null)
-			{
-				_BuildEvents = _dte.Events.BuildEvents;
-				_BuildEvents.OnBuildBegin += MakeXibsNone;
-				_BuildEvents.OnBuildDone += MakeXibsPage;
-			}
-			else
-			{
-				throw new Exception();
-			}
+            if (_dte != null)
+            {
+                _BuildEvents = _dte.Events.BuildEvents;
+                _BuildEvents.OnBuildBegin += MakeXibsNone;
+                _BuildEvents.OnBuildDone += MakeXibsPage;
+            }
+            else
+            {
+                throw new Exception();
+            }
 
             base.Initialize();
         }
 
         private void MakeXibsNone(vsBuildScope scope, vsBuildAction action)
         {
-			var xibs = FindAllXibsInSolution();
+            var xibs = FindAllXibsInSolution();
             foreach(var xib in xibs)
             {
                 xib.Properties.Item("ItemType").Value = "None";
@@ -61,7 +61,7 @@ namespace Follesoe.VSMonoTouch
 
         private void MakeXibsPage(vsBuildScope Scope, vsBuildAction Action)
         {
-			var xibs = FindAllXibsInSolution();
+            var xibs = FindAllXibsInSolution();
             foreach (var xib in xibs)
             {
                 xib.Properties.Item("ItemType").Value = "Page";


### PR DESCRIPTION
I figured out why the add-in wasn't working for me. There was a premature COM/Interop release happening due to garbage collection that was causing the build events to not fire. In my case they failed every single time. Info on the cause (and solution) can be found here:

http://www.mztools.com/articles/2005/mz2005012.aspx

I fixed this and now the extension is working 100% for me.

The unit test issue I logged however is still failing. I'm not sure why.
