### PR TITLE
Enhancement. See Comment

### DIFF
--- a/VSMonoTouch/ProjectUtils.cs
+++ b/VSMonoTouch/ProjectUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.Shell.Flavor;
 using Microsoft.VisualStudio.Shell.Interop;
 using EnvDTE;
 using IServiceProvider = Microsoft.VisualStudio.OLE.Interop.IServiceProvider;
@@ -10,20 +11,21 @@ namespace Follesoe.VSMonoTouch
     {
         public static string GetProjectTypeGuids(Project proj)
         {
-            string projectTypeGuids = "";
+            var projectTypeGuids = "";
             IVsHierarchy hierarchy;
-            IVsAggregatableProject aggregatableProject;
-            int result;
 
-            object service = GetService(proj.DTE, typeof(IVsSolution));
+            var service = GetService(proj.DTE, typeof(IVsSolution));
             var solution = (IVsSolution)service;
 
-            result = solution.GetProjectOfUniqueName(proj.UniqueName, out hierarchy);
+            var result = solution.GetProjectOfUniqueName(proj.UniqueName, out hierarchy);
 
             if (result == 0)
             {
-                aggregatableProject = (IVsAggregatableProject)hierarchy;
-                aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids);
+                if (hierarchy is IVsAggregatableProjectCorrected)
+                {
+                    var aggregatableProject = (IVsAggregatableProjectCorrected)hierarchy;                    
+                    aggregatableProject.GetAggregateProjectTypeGuids(out projectTypeGuids);
+                }
             }
 
             return projectTypeGuids;
@@ -40,12 +42,11 @@ namespace Follesoe.VSMonoTouch
 
             object service = null;
             IntPtr serviceIntPtr;
-            int hr;
 
-            Guid SIDGuid = guid;
-            Guid IIDGuid = SIDGuid;
+            var sidGuid = guid;
+            var iidGuid = sidGuid;
             var serviceProvider = (IServiceProvider)serviceProviderObject;
-            hr = serviceProvider.QueryService(ref SIDGuid, ref IIDGuid, out serviceIntPtr);
+            var hr = serviceProvider.QueryService(ref sidGuid, ref iidGuid, out serviceIntPtr);
 
             if (hr != 0)
             {

--- a/VSMonoTouch/VSMonoTouch.csproj
+++ b/VSMonoTouch/VSMonoTouch.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RegisterForComInterop>false</RegisterForComInterop>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -52,7 +53,24 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>C:\Program Files (x86)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\VSLangProj.dll</HintPath>
+    </Reference>
+    <Reference Include="VSLangProj100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>C:\Program Files (x86)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\VSLangProj100.dll</HintPath>
+    </Reference>
+    <Reference Include="VSLangProj2, Version=7.0.5000.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>C:\Program Files (x86)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\VSLangProj2.dll</HintPath>
+    </Reference>
+    <Reference Include="VSLangProj80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>C:\Program Files (x86)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\VSLangProj80.dll</HintPath>
+    </Reference>
+    <Reference Include="VSLangProj90, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+      <HintPath>C:\Program Files (x86)\Common Files\Microsoft Shared\MSEnv\PublicAssemblies\VSLangProj90.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/VSMonoTouch/source.extension.vsixmanifest
+++ b/VSMonoTouch/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
   <Identifier Id="4e51e215-eb16-4614-b6d2-92e6e1d8c204">
     <Name>MonoTouch for Visual Studio 2010</Name>
     <Author>Follesoe</Author>
-    <Version>1.0</Version>
+    <Version>1.2</Version>
     <Description xml:space="preserve">Load and build MonoTouch projects in Visual Studio 2010</Description>
     <Locale>1033</Locale>
     <MoreInfoUrl>https://github.com/follesoe/VSMonoTouch</MoreInfoUrl>


### PR DESCRIPTION
MonoDevelop 2.8 likes to remove the TargetFrameworkVersion attribute from the project. This will make sure the "v1.0" tag sticks when it gets loaded into visual studio.
