### PR TITLE
Fix for  MonoTouch v5 projects

### DIFF
--- a/VSMonoTouch/Properties/AssemblyInfo.cs
+++ b/VSMonoTouch/Properties/AssemblyInfo.cs
@@ -29,8 +29,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("1.2.0.0")]
-[assembly: AssemblyFileVersion("1.2.0.0")]
+[assembly: AssemblyVersion("1.2.1.0")]
+[assembly: AssemblyFileVersion("1.2.1.0")]
 
 [assembly: InternalsVisibleTo("VSMonoTouch_IntegrationTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db5f6823765cc0097d3f29e2657fee0d71b1ae26a2c6f114d719dd062d9052f64e6951f8f131fb019bb2463f9d1ea48855fd16e52cce9382161693df2666f895c07ee60bc5c14d3cbedfd677551bf7df715cce0489fe599d68bb303d1b4e07a4aa985511ebbc8c9de80240252184b1dc0a1fcf3c63883da29beceef5f0bb8e8e")]
 [assembly: InternalsVisibleTo("VSMonoTouch_UnitTests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100db5f6823765cc0097d3f29e2657fee0d71b1ae26a2c6f114d719dd062d9052f64e6951f8f131fb019bb2463f9d1ea48855fd16e52cce9382161693df2666f895c07ee60bc5c14d3cbedfd677551bf7df715cce0489fe599d68bb303d1b4e07a4aa985511ebbc8c9de80240252184b1dc0a1fcf3c63883da29beceef5f0bb8e8e")]

--- a/VSMonoTouch/VSMonoTouchPackage.cs
+++ b/VSMonoTouch/VSMonoTouchPackage.cs
@@ -35,6 +35,7 @@ namespace Follesoe.VSMonoTouch
         private readonly SolutionEvents _solutionEvents = new SolutionEvents();
         private uint _solutionEventsCookie;
         private IVsSolution _solution;
+		private string XibBuildType = null;
 
         protected override void Initialize()
         {
@@ -68,6 +69,7 @@ namespace Follesoe.VSMonoTouch
             var xibs = FindAllXibsInSolution();
             foreach(var xib in xibs)
             {
+				if (XibBuildType == null) XibBuildType = (string)(xib.Properties.Item("ItemType").Value);
                 xib.Properties.Item("ItemType").Value = "None";
             }
         }
@@ -77,7 +79,7 @@ namespace Follesoe.VSMonoTouch
             var xibs = FindAllXibsInSolution();
             foreach (var xib in xibs)
             {
-                xib.Properties.Item("ItemType").Value = "Page";
+				xib.Properties.Item("ItemType").Value = XibBuildType;
             }
         }
 

--- a/VSMonoTouch/source.extension.vsixmanifest
+++ b/VSMonoTouch/source.extension.vsixmanifest
@@ -1,29 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Vsix xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="1.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2010">
-  <Identifier Id="4e51e215-eb16-4614-b6d2-92e6e1d8c204">
-    <Name>MonoTouch for Visual Studio 2010</Name>
-    <Author>Jonas Follesø, David Jade, Lunat1k, </Author>
-    <Version>1.2</Version>
-    <Description xml:space="preserve">Load and build MonoTouch projects in Visual Studio 2010</Description>
-    <Locale>1033</Locale>
-    <MoreInfoUrl>https://github.com/follesoe/VSMonoTouch</MoreInfoUrl>
-    <GettingStartedGuide>https://github.com/follesoe/VSMonoTouch</GettingStartedGuide>
-    <InstalledByMsi>false</InstalledByMsi>
-    <SupportedProducts>
-      <VisualStudio Version="10.0">
-        <Edition>Ultimate</Edition>
-        <Edition>Premium</Edition>
-        <Edition>Pro</Edition>
-      </VisualStudio>
-    </SupportedProducts>
-    <SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.0" />
-  </Identifier>
-  <References>
-    <Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
-      <Name>Visual Studio MPF</Name>
-    </Reference>
-  </References>
-  <Content>
-    <VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
-  </Content>
+	<Identifier Id="4e51e215-eb16-4614-b6d2-92e6e1d8c204">
+		<Name>MonoTouch for Visual Studio 2010</Name>
+		<Author>Jonas Follesø, David Jade, Lunat1k, </Author>
+		<Version>1.21</Version>
+		<Description xml:space="preserve">Load and build MonoTouch projects in Visual Studio 2010</Description>
+		<Locale>1033</Locale>
+		<MoreInfoUrl>https://github.com/follesoe/VSMonoTouch</MoreInfoUrl>
+		<GettingStartedGuide>https://github.com/follesoe/VSMonoTouch</GettingStartedGuide>
+		<InstalledByMsi>false</InstalledByMsi>
+		<SupportedProducts>
+			<VisualStudio Version="10.0">
+				<Edition>Ultimate</Edition>
+				<Edition>Premium</Edition>
+				<Edition>Pro</Edition>
+			</VisualStudio>
+		</SupportedProducts>
+		<SupportedFrameworkRuntimeEdition MinVersion="4.0" MaxVersion="4.0" />
+	</Identifier>
+	<References>
+		<Reference Id="Microsoft.VisualStudio.MPF" MinVersion="10.0">
+			<Name>Visual Studio MPF</Name>
+		</Reference>
+	</References>
+	<Content>
+		<VsPackage>|%CurrentProject%;PkgdefProjectOutputGroup|</VsPackage>
+	</Content>
 </Vsix>


### PR DESCRIPTION
MonoTouch v5 changed the build type for .xib files in .csproj files. I've made a quick update to this project to detect the build type being used in the .csproj and to flip between that and "none" so that it preserves whatever build type is in the project. Note that I used a very simple detection type (i.e. first instance seen) which may not be ideal.

Also, MonoDevelop likes to put in xml namespace attributes in .csproj files that VS does not like. These .csproj files have to be edited for VS to load them. I've been just removing those namespace references and it doesn't seem to break MonoTouch builds but I haven't tested it extensively. Something should probably be put in the readme about this.
